### PR TITLE
Cache SNS signing certificate

### DIFF
--- a/src/Controllers/AwsSnsController.php
+++ b/src/Controllers/AwsSnsController.php
@@ -5,6 +5,7 @@ namespace JoggApp\AwsSns\Controllers;
 use Aws\Sns\Exception\InvalidSnsMessageException;
 use Aws\Sns\Message;
 use Aws\Sns\MessageValidator;
+use Illuminate\Support\Facades\Cache;
 use JoggApp\AwsSns\Events\SnsMessageReceived;
 use JoggApp\AwsSns\Events\SnsTopicSubscriptionConfirmed;
 
@@ -14,7 +15,11 @@ class AwsSnsController
     {
         $message = Message::fromRawPostData();
 
-        $validator = new MessageValidator();
+        $validator = new MessageValidator(function ($certUrl) {
+            return Cache::rememberForever($certUrl, function ($certUrl) {
+                return file_get_contents($certUrl);
+            });
+        });
 
         try {
             $validator->validate($message);

--- a/src/Controllers/AwsSnsController.php
+++ b/src/Controllers/AwsSnsController.php
@@ -16,7 +16,7 @@ class AwsSnsController
         $message = Message::fromRawPostData();
 
         $validator = new MessageValidator(function ($certUrl) {
-            return Cache::rememberForever($certUrl, function ($certUrl) {
+            return Cache::rememberForever($certUrl, function () use ($certUrl) {
                 return file_get_contents($certUrl);
             });
         });


### PR DESCRIPTION
Following `MessageValidator` implementation, https://github.com/aws/aws-php-sns-message-validator/blob/master/src/MessageValidator.php#L58-L60 construct() method accepts a custom Callable to download the certificate. Caching certificate reduce processing time of incoming SNS messages.

I used `Cache::rememberForever` since AWS change URL when certificate rotate. Source: https://forums.aws.amazon.com/thread.jspa?threadID=174730

However, unlike current certificate downloader implementation in MessageValidator, I didn't used `@` error control operator. Precisely to not cache (forever) bad values in case of fetching failure.