### PR TITLE
Remove requirement for allow_url_fopen

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,9 +23,10 @@
     },
     "require": {
         "php": "^8.0",
-        "illuminate/support": "^9.0",
+        "aws/aws-php-sns-message-validator": "^1.6",
+        "illuminate/http": "^9.0",
         "illuminate/queue": "^9.0",
-        "aws/aws-php-sns-message-validator": "^1.6"
+        "illuminate/support": "^9.0"
     },
     "extra": {
         "laravel": {

--- a/src/Controllers/AwsSnsController.php
+++ b/src/Controllers/AwsSnsController.php
@@ -6,6 +6,7 @@ use Aws\Sns\Exception\InvalidSnsMessageException;
 use Aws\Sns\Message;
 use Aws\Sns\MessageValidator;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
 use JoggApp\AwsSns\Events\SnsMessageReceived;
 use JoggApp\AwsSns\Events\SnsTopicSubscriptionConfirmed;
 
@@ -17,7 +18,7 @@ class AwsSnsController
 
         $validator = new MessageValidator(function ($certUrl) {
             return Cache::rememberForever($certUrl, function () use ($certUrl) {
-                return file_get_contents($certUrl);
+                return Http::get($certUrl);
             });
         });
 
@@ -30,7 +31,7 @@ class AwsSnsController
 
         if (isset($message['Type']) && $message['Type'] === 'SubscriptionConfirmation') {
             // Confirm the subscription by sending a GET request to the SubscribeURL
-            file_get_contents($message['SubscribeURL']);
+            Http::get($message['SubscribeURL']);
 
             event(new SnsTopicSubscriptionConfirmed);
 

--- a/src/Controllers/AwsSnsController.php
+++ b/src/Controllers/AwsSnsController.php
@@ -18,7 +18,7 @@ class AwsSnsController
 
         $validator = new MessageValidator(function ($certUrl) {
             return Cache::rememberForever($certUrl, function () use ($certUrl) {
-                return Http::get($certUrl);
+                return Http::get($certUrl)->body();
             });
         });
 


### PR DESCRIPTION
A lot of production environments have [allow_fopen_url](https://www.php.net/manual/en/filesystem.configuration.php#ini.allow-url-fopen) disabled.

This change makes the package use the internal HTTP handler, which uses guzzle.